### PR TITLE
:sparkles: Display donation summary in a month

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/stripe": "^7.13.25",
     "body-parser": "^1.19.0",
     "class-validator": "^0.12.2",
+    "dayjs": "^1.9.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.4",

--- a/src/controller/index_controller.ts
+++ b/src/controller/index_controller.ts
@@ -1,4 +1,6 @@
 import { Express } from "express";
+import day from "dayjs";
+import stripe from "../config/stripe";
 import { Result } from "../entity/Result";
 import getCurrentUser from "../lib/get_current_user";
 import auth from "../middleware/auth";
@@ -12,7 +14,27 @@ const index = R(async (req, res) => {
   const user = getCurrentUser(req);
   const todayResult = await Result.today(user);
 
-  res.render("index", { user, todayResult });
+  const apiResponse = await stripe.paymentIntents.list({
+    customer: user.stripeId,
+    created: {
+      gte: Math.floor(
+        day()
+          .set("day", 0)
+          .set("h", 0)
+          .set("m", 0)
+          .set("s", 0)
+          .set("ms", 0)
+          .toDate()
+          .getTime() / 1000
+      ),
+    },
+  });
+  const paymentIntents = apiResponse.data;
+  const sum = paymentIntents.reduce((sum, paymentIntent) => {
+    return sum + paymentIntent.amount_received;
+  }, 0);
+
+  res.render("index", { user, todayResult, sum });
 });
 
 export default indexRouting;

--- a/template/index.pug
+++ b/template/index.pug
@@ -19,3 +19,7 @@ block content
     .mt-2.mb-2
       a
         i.fas.fa-chart-line 統計を見る
+
+    .my-2
+      p 今月の支払額
+      h4 #{ sum } 円

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,6 +1694,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.5.tgz#fd49994ebe71639d2ce9575e97186642dfce9808"
+  integrity sha512-WULIw7UpW/E0y6VywewpbXAMH3d5cZijEhoHLwM+OMVbk/NtchKS/W+57H/0P1rqU7gHrAArjiRLHCUhgMQl6w==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
今月の募金額を表示できるようにしました

<img width="301" alt="Screen Shot 2020-11-06 at 12 38 51" src="https://user-images.githubusercontent.com/44729662/98323396-07b74300-202d-11eb-9666-edea724e38d3.png">
